### PR TITLE
Separating spacy, scipy and pyjarowinkler into their own dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,15 +36,12 @@ readme = "README.md"
 # include = ["LICENSE"]
 dependencies = [
     "fairseq>=0.12.2",
-    "nltk>=3.5",
+    "nltk>=3.5",  # parser
     "reynir>=3.5.0",
     "transformers>=4.3.2",
-    "spacy>=2",
-    "pyjarowinkler>=1.8",
-    "scipy>=1.5",
     "sentencepiece>=0.1.96",
-    "langid>=1.1.6",
-    "editdistance>=0.6.0"
+    "langid>=1.1.6",  # filters
+    "editdistance>=0.6.0"  # filters
 ]
 
 [project.scripts]
@@ -62,6 +59,11 @@ dev = [
     "flake8>=3.8.4",
     "mypy>=0.812"
     ]
+ner_processing = [
+    "spacy>=2",
+    "pyjarowinkler>=1.8",
+    "scipy>=1.5",
+]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "greynirseq"
-version = "0.5"
+version = "0.5.1"
 description = "Natural language processing for Icelandic"
 authors = [{name = "Miðeind ehf", email="tauganet@mideind.is"}]
 classifiers = [
@@ -59,7 +59,7 @@ dev = [
     "flake8>=3.8.4",
     "mypy>=0.812"
     ]
-ner_processing = [
+ner-pipeline = [
     "spacy>=2",
     "pyjarowinkler>=1.8",
     "scipy>=1.5",

--- a/src/greynirseq/ner/README.md
+++ b/src/greynirseq/ner/README.md
@@ -2,6 +2,13 @@
 
 In training data for NMT (neural machine translation) systems it is of benefit to have a large and varried corpus. Unfortunately this is not often the case. This submodule implements a pipeline for tagging, filtering, matching and substituing named entities in a parallel English to Icelandic corpus. Currently it only support Persons but it should not be much work to extend this to other label sets.
 
+## Installation
+For local installation, clone the repository and install the package with pip
+
+```bash
+pip install -e .[ner-pipeline]  # extra dependencies for the pipeline
+```
+
 ### Name Tagging
 
 For Icelandic NER the included IceBERT-NER model is used. For english a NER model fine tuned on BERT large from huggingface is used with spacy as fallback (`python -m spacy download en_core_web_lg`) if sentence length is too long for the model to process. Note that this results in downloading of data beyond 1Gb.


### PR DESCRIPTION
I tested this by running the translation cli. I could not find any imports of the ner modules so these dependencies should be contained.